### PR TITLE
Added scissor support to cut hides into leather

### DIFF
--- a/RazorScripts/Butcher.cs
+++ b/RazorScripts/Butcher.cs
@@ -24,6 +24,7 @@ namespace Razorscripts
         private int _lambLeg = 0x1609;
         private int _dragonscale = 0x26B4;
         private int _dragonblood = 0x4077;
+		private int _scissors = 0x0F9F;
 
         private readonly List<int> _daggers =
             new[]
@@ -35,6 +36,8 @@ namespace Razorscripts
                 0x13F6, //Butchers Knife
                 0x13B6, //Butchers Knife
             }.ToList();
+            
+        private Item _scissorsItem;
 
         public void Run()
         {
@@ -78,6 +81,14 @@ namespace Razorscripts
             }
 
             var isHarvestersBlade = dagger.Name == "Harvester's Blade";
+
+            _scissorsItem = DigDeep(Player.Backpack, _scissors);
+
+            if (_scissorsItem == null)
+            {
+                Misc.SendMessage("Unable to locate scissors", 201);
+                return;
+            }
 
             var corpses = Items.ApplyFilter(new Items.Filter
             {
@@ -201,9 +212,23 @@ namespace Razorscripts
         private void LootItems(Item corpse, int itemId, string name = null)
         {
             var stack = corpse.Contains.Where(i => i.ItemID == itemId && (string.IsNullOrEmpty(name) || i.Name.Contains(name))).ToList();
-            foreach (var feather in stack)
+            foreach (var stackItem in stack)
             {
-                Items.Move(feather, Player.Backpack.Serial, feather?.Amount ?? int.MaxValue);
+                Items.Move(stackItem, Player.Backpack.Serial, stackItem?.Amount ?? int.MaxValue);
+				
+                if (stackItem.ItemID == _hide) 
+                {
+                    Misc.SendMessage("Cutting hides", 201);
+                    Misc.Pause(300);
+                    // After moving, find the item again inside backpack
+                    var moved = Player.Backpack.Contains.FirstOrDefault(i => i.ItemID == itemId);
+                    if (moved != null && moved.ItemID == _hide)
+                    {
+                        Items.UseItem(_scissorsItem);
+                        Target.WaitForTarget(2000);
+                        Target.TargetExecute(moved);
+                    }
+                }
                 Misc.Pause(100);
             }
         }

--- a/RazorScripts/Butcher.cs
+++ b/RazorScripts/Butcher.cs
@@ -86,8 +86,7 @@ namespace Razorscripts
 
             if (_scissorsItem == null)
             {
-                Misc.SendMessage("Unable to locate scissors", 201);
-                return;
+                Misc.SendMessage("Scissors not found, hides will not be cut.", 201);
             }
 
             var corpses = Items.ApplyFilter(new Items.Filter
@@ -215,8 +214,8 @@ namespace Razorscripts
             foreach (var stackItem in stack)
             {
                 Items.Move(stackItem, Player.Backpack.Serial, stackItem?.Amount ?? int.MaxValue);
-				
-                if (stackItem.ItemID == _hide) 
+                
+                if (stackItem.ItemID == _hide && _scissorsItem != null) 
                 {
                     Misc.SendMessage("Cutting hides", 201);
                     Misc.Pause(300);


### PR DESCRIPTION
This addition will use scissors found in your pack to cut looted hides into leather to preserve weight. 
If no scissors are found, only a message is displayed in the journal.